### PR TITLE
Fix CNC serial port listing

### DIFF
--- a/cnc/cnc_serial.py
+++ b/cnc/cnc_serial.py
@@ -61,7 +61,8 @@ class CNCSerial:
         import threading; threading.Thread(target=_worker, daemon=True).start()
 
     @staticmethod
-    def list_serial_ports(self):
+    def list_serial_ports():
+        """Return available serial port device names."""
         return [port.device for port in serial.tools.list_ports.comports()]
 
     


### PR DESCRIPTION
## Summary
- correct `list_serial_ports` in `CNCSerial`

## Testing
- `python -m py_compile main.py gui/my_gui.py cnc/cnc_serial.py nir1/wasatch.py`

------
https://chatgpt.com/codex/tasks/task_e_6852977ba8a883298b40ae70e39606cd